### PR TITLE
[REFACTOR] 수정 후 메인페이지 즉시 반영

### DIFF
--- a/src/components/timer/CountdownTimer.jsx
+++ b/src/components/timer/CountdownTimer.jsx
@@ -18,10 +18,11 @@ const DetailColor = color => {
 const CountdownTimer = ({timer, onTimerClick}) => {
   const navigation = useNavigation();
   const timerStore = useTimerStore();
+  console.log('countdowntimer', timer);
   const currentTimer = useTimerStore(state => state.timers[timer.id]);
 
   useEffect(() => {
-    if (!currentTimer) {
+    if (!currentTimer || currentTimer !== timer) {
       timerStore.initTimer(
         timer.id,
         timer.totalMinutes,
@@ -29,7 +30,7 @@ const CountdownTimer = ({timer, onTimerClick}) => {
         timer.detailTimerData,
       );
     }
-  }, [timer.id]);
+  }, [timer]);
 
   const calculateProgress = () => {
     if (!currentTimer) return 0;

--- a/src/pages/TimerUpdatePage.jsx
+++ b/src/pages/TimerUpdatePage.jsx
@@ -17,7 +17,6 @@ import {useNavigation, useRoute} from '@react-navigation/native';
 const TimerUpdatePage = () => {
   const route = useRoute();
   const {timer} = route.params || {};
-  console.log(timer);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [selectedIcon, setSelectedIcon] = useState(timer.icon);
   const [timerName, setTimerName] = useState(timer.timerName);


### PR DESCRIPTION
## #️⃣ 연관 이슈
#103 

## 📝 작업 내용
### countdownTimer에서 수정 시 내용이 즉시 반영되지 않는 문제
- countdownTimer 내부에 있는 currentTimer를 갱신하는 useEffect에서 timer.id가 변경될 때만 timer를 갱신하도록 되어있었다.
이로 인해서 timer 자체를 참조하는 데이터 (color, name 등)은 즉각적으로 갱신이 되었지만 전역변수 참조를 위해 currentTimer를 참조하는 데이터들은 갱신되지 않는 문제가 발생
timer의 내용이 변경 되었을 경우에도 currentTimer를 갱신할 수 있도록 해 문제를 해결

## 💬 리뷰 요구사항(선택)