### PR TITLE
[REFACTOR] 구글 로그인 시도 중단 시 로그인 화면 유지

### DIFF
--- a/src/components/googleapi/GoogleDriveService.jsx
+++ b/src/components/googleapi/GoogleDriveService.jsx
@@ -1,5 +1,6 @@
 import { GoogleSignin, isSuccessResponse } from '@react-native-google-signin/google-signin';
 import { IOS_CLIENT_ID, WEB_CLIENT_ID } from '@env';
+import { Alert } from 'react-native';
 
 export default class GoogleDriveService {
     constructor(config = {}) {
@@ -31,6 +32,7 @@ export default class GoogleDriveService {
             return isSuccessResponse(await GoogleSignin.signIn());
         } catch (error) {
             console.error('Google login error:', error);
+            Alert.alert('로그인 실패', '알 수 없는 오류로 인해 로그인에 실패했습니다.');
             return false;
         }
     }

--- a/src/components/googleapi/GoogleLoginButton.jsx
+++ b/src/components/googleapi/GoogleLoginButton.jsx
@@ -10,9 +10,11 @@ const GoogleLoginButton = () => {
   const navigation = useNavigation();
   return (
     <ButtonContainer onPress={async () => {
-        await (new GoogleDriveService()).signinExplicitly();
-        await AsyncStorage.setItem('isFirstUser', 'false');
-        navigation.goBack();
+        const result = await (new GoogleDriveService()).signinExplicitly();
+        if(result) {
+          await AsyncStorage.setItem('isFirstUser', 'false');
+          navigation.goBack();
+        } ;
     }} activeOpacity={1}>
       <ContentContainer>
         <GoogleIcon


### PR DESCRIPTION

## #️⃣ 연관 이슈
#143 

## 📝 작업 내용
- 로그인 도중 중단할 시, 로그인 페이지 유지
- 네트워크 오류 등의 문제로 로그인 실패 시 alert 알림 이후 로그인 페이지 유지


## 💬 리뷰 요구사항(선택)