### PR TITLE
[FEAT] 타이머 삭제 모드 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ function App(): React.JSX.Element {
               }}>
               <Stack.Screen
                 name="Main"
-                component={MainWithLayout}
+                component={MainPage}
                 options={{title: 'Main Page', animation: 'none'}}
               />
               <Stack.Screen
@@ -52,12 +52,12 @@ function App(): React.JSX.Element {
               />
               <Stack.Screen
                 name="Create Timer"
-                component={TimerCreateWithLayout}
+                component={TimerCreatePage}
                 options={{title: 'Create Timer Page'}}
               />
               <Stack.Screen
                 name="Create Folder"
-                component={FolderCreateWithLayout}
+                component={FolderCreatePage}
                 options={{title: 'Create Folder Page'}}
               />
               <Stack.Screen
@@ -67,7 +67,7 @@ function App(): React.JSX.Element {
               />
               <Stack.Screen
                 name="Timer Update"
-                component={TimerUpdateWithLayout}
+                component={TimerUpdatePage}
                 options={{title: 'Timer Update Page'}}
               />
               <Stack.Screen
@@ -101,19 +101,11 @@ const FolderPageWithLayout = () => (
   </BaseLayout>
 );
 
-const MainWithLayout = () => <MainPage />;
-
 const DetailWithLayout = () => (
   <BaseLayout>
     <DetailPage />
   </BaseLayout>
 );
-
-const TimerCreateWithLayout = () => <TimerCreatePage />;
-
-const TimerUpdateWithLayout = () => <TimerUpdatePage />;
-
-const FolderCreateWithLayout = () => <FolderCreatePage />;
 
 export default App;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,11 +101,7 @@ const FolderPageWithLayout = () => (
   </BaseLayout>
 );
 
-const MainWithLayout = () => (
-  <BaseLayout>
-    <MainPage />
-  </BaseLayout>
-);
+const MainWithLayout = () => <MainPage />;
 
 const DetailWithLayout = () => (
   <BaseLayout>

--- a/src/components/timer/CountdownTimer.jsx
+++ b/src/components/timer/CountdownTimer.jsx
@@ -16,7 +16,12 @@ const DetailColor = color => {
   if (color === '#FCC4C4') return '#F4A7A3';
 };
 
-const CountdownTimer = ({timer, onTimerClick}) => {
+const CountdownTimer = ({
+  timer,
+  onTimerClick,
+  setIsDeleteMode,
+  isDeleteMode,
+}) => {
   const navigation = useNavigation();
   const timerStore = useTimerStore();
   const currentTimer = useTimerStore(state => state.timers[timer.id]);
@@ -58,9 +63,15 @@ const CountdownTimer = ({timer, onTimerClick}) => {
     }
   };
 
-  const handleLongPress = () => {};
+  const handleLongPress = () => {
+    setIsDeleteMode(true);
+  };
 
   const handlePress = () => {
+    if (isDeleteMode) {
+      setIsDeleteMode(false);
+      return;
+    }
     navigation.navigate('Detail', {timer});
     setTimeout(() => {
       onTimerClick(timer);
@@ -72,10 +83,12 @@ const CountdownTimer = ({timer, onTimerClick}) => {
 
   return (
     <Container>
-      <FolderDeleteButton
-        onDelete={() => deleteTimerData(timer.id)}
-        id={timer.id}
-      />
+      {isDeleteMode && (
+        <FolderDeleteButton
+          onDelete={() => deleteTimerData(timer.id)}
+          id={timer.id}
+        />
+      )}
       <TouchableWithoutFeedback
         onPress={handlePress}
         onLongPress={handleLongPress}>

--- a/src/components/timer/CountdownTimer.jsx
+++ b/src/components/timer/CountdownTimer.jsx
@@ -90,7 +90,7 @@ const CountdownTimer = ({
         />
       )}
       <TouchableWithoutFeedback
-        onPress={handlePress}
+        onPress={isDeleteMode ? () => {} : handlePress}
         onLongPress={handleLongPress}>
         <TimerContainer>
           <BackgroundView color={timer.timerColor} />

--- a/src/components/timer/CountdownTimer.jsx
+++ b/src/components/timer/CountdownTimer.jsx
@@ -7,6 +7,7 @@ import useTimerStore from '../../store';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {useEffect} from 'react';
 import FolderDeleteButton from './FolderDeleteButton';
+
 const DetailColor = color => {
   if (color === '#FBDF60') return '#FFC15B';
   if (color === '#F6DBB7') return '#E9B97E';
@@ -42,11 +43,13 @@ const CountdownTimer = ({timer, onTimerClick}) => {
 
   const deleteTimerData = async id => {
     try {
+      console.log(id);
       const storedTimers = await AsyncStorage.getItem('timers');
-      const updatedTimers = (storedTimers ? storedTimers : []).filter(
-        parsedTimer => parsedTimer.id !== id,
-      );
-      await AsyncStorage.save('timers', updatedTimers);
+      const updatedTimers = (
+        storedTimers ? JSON.parse(storedTimers) : []
+      ).filter(parsedTimer => parsedTimer.id !== id);
+
+      await AsyncStorage.setItem('timers', JSON.stringify(updatedTimers));
       Alert.alert('삭제 완료', '타이머가 성공적으로 삭제되었습니다.');
       navigation.replace('Main', {animation: 'none'});
     } catch (error) {
@@ -55,19 +58,7 @@ const CountdownTimer = ({timer, onTimerClick}) => {
     }
   };
 
-  const handleLongPress = () => {
-    Alert.alert(
-      '타이머 삭제',
-      '삭제한 타이머는 되돌릴 수 없습니다. 삭제하시겠습니까?',
-      [
-        {
-          text: '취소',
-          style: 'cancel',
-        },
-        {text: '삭제', onPress: () => deleteTimerData(timer.id)},
-      ],
-    );
-  };
+  const handleLongPress = () => {};
 
   const handlePress = () => {
     navigation.navigate('Detail', {timer});
@@ -81,7 +72,10 @@ const CountdownTimer = ({timer, onTimerClick}) => {
 
   return (
     <Container>
-      <FolderDeleteButton onDelete={handleLongPress} />
+      <FolderDeleteButton
+        onDelete={() => deleteTimerData(timer.id)}
+        id={timer.id}
+      />
       <TouchableWithoutFeedback
         onPress={handlePress}
         onLongPress={handleLongPress}>
@@ -125,9 +119,7 @@ const CountdownTimer = ({timer, onTimerClick}) => {
 
 const Container = styled.View`
   z-index: 1;
-  padding-left: ${scale(2)}px;
   position: relative;
-  width: 45%;
 `;
 
 const TimerContainer = styled.View`

--- a/src/components/timer/CountdownTimer.jsx
+++ b/src/components/timer/CountdownTimer.jsx
@@ -125,7 +125,9 @@ const CountdownTimer = ({timer, onTimerClick}) => {
 
 const Container = styled.View`
   z-index: 1;
+  padding-left: ${scale(2)}px;
   position: relative;
+  width: 45%;
 `;
 
 const TimerContainer = styled.View`

--- a/src/components/timer/CountdownTimer.jsx
+++ b/src/components/timer/CountdownTimer.jsx
@@ -6,7 +6,7 @@ import {useNavigation} from '@react-navigation/native';
 import useTimerStore from '../../store';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {useEffect} from 'react';
-
+import FolderDeleteButton from './FolderDeleteButton';
 const DetailColor = color => {
   if (color === '#FBDF60') return '#FFC15B';
   if (color === '#F6DBB7') return '#E9B97E';
@@ -80,45 +80,53 @@ const CountdownTimer = ({timer, onTimerClick}) => {
   const darkerColor = DetailColor(timer.timerColor);
 
   return (
-    <TouchableWithoutFeedback
-      onPress={handlePress}
-      onLongPress={handleLongPress}>
-      <TimerContainer>
-        <BackgroundView color={timer.timerColor} />
-        <ProgressView
-          color={darkerColor}
-          style={{
-            position: 'absolute',
-            right: 0,
-            width: `${progress * 100}%`,
-            height: '100%',
-            borderTopRightRadius: scale(13),
-            borderBottomRightRadius: scale(13),
-          }}
-        />
-        <ContentWrapper>
-          <TimerHeaderWrapper>
-            <IconboxWrapper>
-              <IconView>{timer.icon}</IconView>
-            </IconboxWrapper>
-            <EnterImage
-              source={require('../../assets/images/timerBox/enter-arrow.png')}
-            />
-          </TimerHeaderWrapper>
-          <FoodTitleText weight="semi-bold">{timer.timerName}</FoodTitleText>
-          <TimerText weight="bold">
-            {currentTimer
-              ? `${String(currentTimer.totalTime.minutes).padStart(
-                  2,
-                  '0',
-                )}:${String(currentTimer.totalTime.seconds).padStart(2, '0')}`
-              : '00:00'}
-          </TimerText>
-        </ContentWrapper>
-      </TimerContainer>
-    </TouchableWithoutFeedback>
+    <Container>
+      <FolderDeleteButton onDelete={handleLongPress} />
+      <TouchableWithoutFeedback
+        onPress={handlePress}
+        onLongPress={handleLongPress}>
+        <TimerContainer>
+          <BackgroundView color={timer.timerColor} />
+          <ProgressView
+            color={darkerColor}
+            style={{
+              position: 'absolute',
+              right: 0,
+              width: `${progress * 100}%`,
+              height: '100%',
+              borderTopRightRadius: scale(13),
+              borderBottomRightRadius: scale(13),
+            }}
+          />
+          <ContentWrapper>
+            <TimerHeaderWrapper>
+              <IconboxWrapper>
+                <IconView>{timer.icon}</IconView>
+              </IconboxWrapper>
+              <EnterImage
+                source={require('../../assets/images/timerBox/enter-arrow.png')}
+              />
+            </TimerHeaderWrapper>
+            <FoodTitleText weight="semi-bold">{timer.timerName}</FoodTitleText>
+            <TimerText weight="bold">
+              {currentTimer
+                ? `${String(currentTimer.totalTime.minutes).padStart(
+                    2,
+                    '0',
+                  )}:${String(currentTimer.totalTime.seconds).padStart(2, '0')}`
+                : '00:00'}
+            </TimerText>
+          </ContentWrapper>
+        </TimerContainer>
+      </TouchableWithoutFeedback>
+    </Container>
   );
 };
+
+const Container = styled.View`
+  z-index: 1;
+  position: relative;
+`;
 
 const TimerContainer = styled.View`
   width: ${scale(140)}px;

--- a/src/components/timer/FolderDeleteButton.jsx
+++ b/src/components/timer/FolderDeleteButton.jsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components/native';
+import Icon from 'react-native-vector-icons/MaterialIcons';
+import {scale} from 'react-native-size-matters';
+import {TouchableWithoutFeedback} from 'react-native';
+
+const FolderDeleteButton = ({style, onDelete}) => {
+  return (
+    <Container style={style}>
+      <TouchableWithoutFeedback onPress={onDelete}>
+        <ButtonWrapper>
+          <Icon name="close" size={scale(20)} color="white" />
+        </ButtonWrapper>
+      </TouchableWithoutFeedback>
+    </Container>
+  );
+};
+
+const Container = styled.View``;
+
+const ButtonWrapper = styled.View`
+  z-index: 1;
+  justify-content: center;
+  align-items: flex-start;
+  border-radius: ${scale(30)}px;
+  position: absolute;
+  right: ${scale(-5)}px;
+  top: ${scale(-5)}px;
+  background-color: red;
+  width: ${scale(20)}px;
+  height: ${scale(20)}px;
+`;
+
+export default FolderDeleteButton;

--- a/src/components/timer/FolderDeleteButton.jsx
+++ b/src/components/timer/FolderDeleteButton.jsx
@@ -2,11 +2,21 @@ import styled from 'styled-components/native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import {scale} from 'react-native-size-matters';
 import {TouchableWithoutFeedback} from 'react-native';
+import {Alert} from 'react-native';
 
-const FolderDeleteButton = ({style, onDelete}) => {
+const onClick = (onDelete, id) => {
+  Alert.alert('삭제', '삭제하시겠습니까?', [
+    {text: '취소', style: 'cancel'},
+    {text: '삭제', onPress: () => onDelete(id)},
+  ]);
+};
+
+const FolderDeleteButton = ({style, onDelete, id}) => {
+  console.log(onDelete);
+
   return (
     <Container style={style}>
-      <TouchableWithoutFeedback onPress={onDelete}>
+      <TouchableWithoutFeedback onPress={() => onClick(onDelete, id)}>
         <ButtonWrapper>
           <Icon name="close" size={scale(20)} color="white" />
         </ButtonWrapper>

--- a/src/components/timer/FolderDeleteButton.jsx
+++ b/src/components/timer/FolderDeleteButton.jsx
@@ -23,8 +23,8 @@ const ButtonWrapper = styled.View`
   align-items: flex-start;
   border-radius: ${scale(30)}px;
   position: absolute;
-  right: ${scale(-5)}px;
   top: ${scale(-5)}px;
+  right: ${scale(-5)}px;
   background-color: red;
   width: ${scale(20)}px;
   height: ${scale(20)}px;

--- a/src/components/timer/FolderDeleteButton.jsx
+++ b/src/components/timer/FolderDeleteButton.jsx
@@ -18,7 +18,7 @@ const FolderDeleteButton = ({style, onDelete, id}) => {
     <Container style={style}>
       <TouchableWithoutFeedback onPress={() => onClick(onDelete, id)}>
         <ButtonWrapper>
-          <Icon name="close" size={scale(20)} color="white" />
+          <Icon name="close" size={scale(20)} color="black" />
         </ButtonWrapper>
       </TouchableWithoutFeedback>
     </Container>
@@ -30,14 +30,14 @@ const Container = styled.View``;
 const ButtonWrapper = styled.View`
   z-index: 1;
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
   border-radius: ${scale(30)}px;
   position: absolute;
   top: ${scale(-5)}px;
   right: ${scale(-5)}px;
-  background-color: red;
-  width: ${scale(20)}px;
-  height: ${scale(20)}px;
+  background-color: #d9d9d9;
+  width: ${scale(25)}px;
+  height: ${scale(25)}px;
 `;
 
 export default FolderDeleteButton;

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -175,10 +175,12 @@ const MainPage = () => {
 
   return (
     <MainContainer>
+      <HeaderWrapper>
+        <Header type="main" />
+      </HeaderWrapper>
       <ScrollView
         contentContainerStyle={{flexGrow: 1}}
         showsVerticalScrollIndicator={false}>
-        <Header type="main" />
         <CountdownTimerWrapper>
           <TimersAndFoldersContainer>
             {items.map(item => (
@@ -207,6 +209,7 @@ export default MainPage;
 
 const MainContainer = styled.View`
   flex-direction: column;
+  padding-top: ${Platform.select({ios: scale(25), android: scale(12)})}px;
   height: 100%;
 `;
 
@@ -221,4 +224,8 @@ const TimersAndFoldersContainer = styled.View`
   flex-wrap: wrap;
   justify-content: flex-start;
   padding-top: ${scale(20)}px;
+`;
+
+const HeaderWrapper = styled.View`
+  padding: 0 ${scale(21)}px;
 `;

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -9,11 +9,12 @@ import {useFocusEffect} from '@react-navigation/native';
 import initialMockData from '../data/initialMockData';
 import {checkFirstUser} from '../utils/checkFirstUser';
 import {useNavigation} from '@react-navigation/native';
+import {TouchableWithoutFeedback} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const MainPage = () => {
-  const navigation = useNavigation();
   const [items, setItems] = useState([]);
+  const [isDeleteMode, setIsDeleteMode] = useState(false);
 
   const loadData = async () => {
     try {
@@ -181,7 +182,11 @@ const MainPage = () => {
       <ScrollView
         contentContainerStyle={{flexGrow: 1}}
         showsVerticalScrollIndicator={false}>
-        <CountdownTimerWrapper>
+        <CountdownTimerWrapper
+          contentContainerStyle={{flexGrow: 1}}
+          onPress={() => {
+            isDeleteMode && setIsDeleteMode(false);
+          }}>
           <TimersAndFoldersContainer>
             {items.map(item => (
               <React.Fragment key={item.id}>
@@ -189,11 +194,15 @@ const MainPage = () => {
                   <CountdownTimer
                     timer={item}
                     onTimerClick={handleTimerClick}
+                    isDeleteMode={isDeleteMode}
+                    setIsDeleteMode={setIsDeleteMode}
                   />
                 ) : (
                   <CountdownFolder
                     folder={item}
                     onFolderClick={handleFolderClick}
+                    isDeleteMode={isDeleteMode}
+                    setIsDeleteMode={setIsDeleteMode}
                   />
                 )}
               </React.Fragment>
@@ -213,9 +222,10 @@ const MainContainer = styled.View`
   height: 100%;
 `;
 
-const CountdownTimerWrapper = styled.View`
-  justify-content: center;
-  align-items: center;
+const CountdownTimerWrapper = styled.Pressable`
+  margin: 0 ${scale(21)}px;
+  height: 100%;
+  width: 100%;
 `;
 
 const TimersAndFoldersContainer = styled.View`

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -210,7 +210,10 @@ const MainContainer = styled.View`
   height: 100%;
 `;
 
-const CountdownTimerWrapper = styled.View``;
+const CountdownTimerWrapper = styled.View`
+  justify-content: center;
+  align-items: center;
+`;
 
 const TimersAndFoldersContainer = styled.View`
   flex-direction: row;


### PR DESCRIPTION
## #️⃣ 연관 이슈
#163 

## 📝 작업 내용
- 폴더 삭제 시 애니메이션 기능을 구현하기 전, 폴더 삭제 모드를 구현합니다. 

### 1. 타이머 삭제 버튼 구현
<img width="285" alt="image" src="https://github.com/user-attachments/assets/ec0a6bfd-5415-4e32-80ea-fe8d499d7386" />

- 폴더 삭제 버튼 스타일을 구현했습니다. 
- 기존 countdownTimer에 구현되어있던 deleteTimerData를 폴더 삭제 버튼에서 작동하도록 코드를 수정했습니다. 

### 2. 타이머 삭제 모드에서 삭제 버튼이 잘리는 문제 해결
<img width="141" alt="image" src="https://github.com/user-attachments/assets/651b66cf-ccd3-4475-aace-f58dd5161895" />

- 기존 BaseLayout으로 인해 폴더 삭제 버튼의 일부분이 잘려 보이는 문제를 해결하기 위해 몇몇 페이지의 Layout 스타일을 수정했습니다. 이로 인해 한 번에 관리되고 있던 공통 padding 값들이 분리되어 들어가게 되었습니다. 

### 3. 타이머 삭제 모드 구현
- 타이머를 길게 누를 시, 삭제 모드로 들어가도록 구현했습니다. 현재 폴더에는 적용되어있지 않기 때문에 확인 필요합니다. (새로 발견된 버그로 인해서 폴더 데이터 추가가 어려워져 구현하지 못했습니다.)
- 타이머 삭제 모드가 실행되었을 시, 삭제 버튼 이외의 다른 화면을 클릭 시 모드가 해제됩니다.
   - 이를 구현하기 위해 countdownTimerWrapper의 태그를 pressable로 변경했습니다
- 애니메이션이 없어 아주 딱딱합니다... 어떤 방식으로든 이 이질감을 줄일 방법의 적용이 필요합니다. 

## 💬 리뷰 요구사항(선택)
1. 2번 문제를 해결하기 위해 변경된 레이아웃 스타일을 조금 더 효율적으로 관리할 방법이 있을까요? 또, 점점 baseLayout을 사용하지 않는 페이지들이 늘어나면서 그 사용성에 대해 함께 논의해보고 싶습니다.
2. 3번 삭제 모드를 해제하는 방법 중 pressable 사용 외에 좋은 방법이 있다면 의견 부탁드리겠습니다.
3. #171 번 이슈에 대해 인지하고 해결 방법에 대한 논의가 필요할 것 같습니다. 