### PR TITLE
[FEAT] 폴더 수정 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Refresh from './pages/Refresh';
 import {GestureHandlerRootView} from 'react-native-gesture-handler';
 import FolderPage from './pages/FolderPage';
 import {useAppStateMonitor} from './hooks/useAppStateMonitor';
+import FolderUpdatePage from './pages/FolderUpdatePage';
 
 const Stack = createNativeStackNavigator();
 
@@ -72,6 +73,11 @@ function App(): React.JSX.Element {
                 name="Refresh"
                 component={Refresh}
                 options={{title: 'Refresh Page'}}
+              />
+              <Stack.Screen
+                name="Folder Update"
+                component={FolderUpdatePage}
+                options={{title: 'Folder Update Page'}}
               />
             </Stack.Group>
 

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -6,7 +6,7 @@ import {useNavigation} from '@react-navigation/native';
 import CustomText from '../CustomText';
 import {useRoute} from '@react-navigation/native';
 
-const Header = ({type, title, onPressComplete, timer}) => {
+const Header = ({type, title, onPressComplete, timer, folder}) => {
   const navigation = useNavigation();
   const route = useRoute();
   const titleWeight = Platform.select({
@@ -19,7 +19,8 @@ const Header = ({type, title, onPressComplete, timer}) => {
       <HeaderContainer>
         <Logo source={require('../../assets/images/header/logo.png')} />
         <IconContainer>
-          <RightTextButton onPress={() => navigation.navigate('Create Modal')}>
+          <RightTextButton
+            onPress={() => navigation.navigate('Create Modal', {})}>
             <IconButton>
               <StyledIcon
                 source={require('../../assets/images/header/plus.png')}
@@ -60,8 +61,8 @@ const Header = ({type, title, onPressComplete, timer}) => {
         <IconContainer>
           <RightTextButton
             onPress={() =>
-              navigation.navigate('Create Timer', {
-                folderId: route.params?.folder?.id,
+              navigation.navigate('Create Modal', {
+                folder: folder,
               })
             }>
             <IconButton>

--- a/src/components/detail/ProgressBar.jsx
+++ b/src/components/detail/ProgressBar.jsx
@@ -2,7 +2,7 @@ import styled from 'styled-components/native';
 import {Dimensions} from 'react-native';
 import {scale} from 'react-native-size-matters';
 import {View} from 'react-native';
-import {FIRE_COLOR} from '../../constants/Color';
+import {FIRE_COLOR} from '../../constants/color';
 const screenWidth = Dimensions.get('window').width;
 
 const ProgressBar = ({timer}) => {

--- a/src/components/modal/newCreateModal/NewCreateModal.jsx
+++ b/src/components/modal/newCreateModal/NewCreateModal.jsx
@@ -11,7 +11,8 @@ import {Alert} from 'react-native';
 import folderIcon from '../../../assets/images/NewCreateModal/folderIcon.png';
 import timerIcon from '../../../assets/images/NewCreateModal/timerIcon.png';
 
-const NewCreateModal = () => {
+const NewCreateModal = ({route}) => {
+  const {folder} = route.params;
   const [isModalVisible, setIsModalVisible] = useState(true);
   const navigation = useNavigation();
 
@@ -32,6 +33,12 @@ const NewCreateModal = () => {
     navigation.navigate('Create Folder');
   };
 
+  const handleUpdateFolder = () => {
+    setIsModalVisible(false);
+    navigation.goBack();
+    navigation.navigate('Folder Update', {folder: folder});
+  };
+
   return (
     <CustomModal visible={isModalVisible} onClose={onPressModalClose}>
       <ModalContainer>
@@ -40,11 +47,19 @@ const NewCreateModal = () => {
           <StyledCloseButton onClose={onPressModalClose} />
         </TitletContainer>
         <ButtonsContainer>
-          <CreateButton
-            onPress={handleCreateFolder}
-            text="폴더 생성"
-            icon={folderIcon}
-          />
+          {folder ? (
+            <CreateButton
+              onPress={handleUpdateFolder}
+              text="폴더 수정"
+              icon={folderIcon}
+            />
+          ) : (
+            <CreateButton
+              onPress={handleCreateFolder}
+              text="폴더 생성"
+              icon={folderIcon}
+            />
+          )}
           <CreateButton
             onPress={handleCreateTimer}
             text="타이머 생성"

--- a/src/pages/FolderPage.jsx
+++ b/src/pages/FolderPage.jsx
@@ -76,6 +76,7 @@ const FolderPage = () => {
           title={folder?.folderName}
           icon={folder?.icon}
           folderId={folder?.id}
+          folder={folder}
         />
         <TimersContainer>
           {timers.length > 0 ? (

--- a/src/pages/FolderUpdatePage.jsx
+++ b/src/pages/FolderUpdatePage.jsx
@@ -1,0 +1,118 @@
+import {useState, useEffect} from 'react';
+import {Platform, Alert, KeyboardAvoidingView} from 'react-native';
+import {scale} from 'react-native-size-matters';
+import CustomText from '../components/CustomText';
+import styled from 'styled-components/native';
+import ColorPicker from '../components/common/ColorPicker';
+import InputComponent from '../components/folderCreate/InputComponent';
+import IconPicker from '../components/common/IconPicker';
+import Header from '../components/common/Header';
+import IconPickerModal from '../components/modal/iconPickerModal/IconPickerModal';
+import {useNavigation, useRoute} from '@react-navigation/native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const FolderUpdatePage = () => {
+  const route = useRoute();
+  const {folder} = route.params || {};
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [selectedIcon, setSelectedIcon] = useState(folder.icon);
+  const [folderName, setFolderName] = useState(folder.folderName);
+  const [folderColor, setFolderColor] = useState(folder.folderColor);
+  const navigation = useNavigation();
+
+  const onPressModalOpen = () => {
+    setIsModalVisible(true);
+  };
+
+  const handleIconSelect = icon => {
+    setSelectedIcon(icon);
+    setIsModalVisible(false);
+  };
+
+  const handleModalClose = () => {
+    setIsModalVisible(false);
+  };
+
+  const updateFolderData = async () => {
+    try {
+      const newFolder = {
+        id: folder.id,
+        folderName: folderName,
+        folderColor: folderColor,
+        icon: selectedIcon,
+        timers: [],
+        createdAt: Date.now(), // 생성 시간 추가
+      };
+
+      const storedFolders = await AsyncStorage.getItem('folders');
+
+      const updatedFolders = (
+        storedFolders ? JSON.parse(storedFolders) : []
+      ).map(f => (f.id === folder.id ? newFolder : f));
+
+      await AsyncStorage.setItem('folders', JSON.stringify(updatedFolders));
+
+      Alert.alert('저장 완료', '폴더가 성공적으로 저장되었습니다.');
+
+      navigation.goBack();
+      navigation.goBack();
+    } catch (error) {
+      console.error('폴더 저장 실패:', error);
+      Alert.alert('저장 실패', '폴더를 저장하는 데 실패했습니다.');
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView>
+      <FolderCreateContainer
+        contentContainerStyle={{flexGrow: 1}}
+        showsVerticalScrollIndicator={false}>
+        <BaseLayout>
+          <Header
+            type="folderCreate"
+            title="폴더 수정"
+            onPressComplete={updateFolderData}
+          />
+          <IconPicker icon={selectedIcon} onPress={onPressModalOpen} />
+          <InsertContainer>
+            <FolderCreateText weight="semi-bold">폴더 이름</FolderCreateText>
+            <InputWrapper value={folderName} onChangeText={setFolderName} />
+            <FolderCreateText weight="semi-bold">폴더 색상</FolderCreateText>
+            <ColorPicker color={folderColor} onChangeColor={setFolderColor} />
+          </InsertContainer>
+
+          {isModalVisible && (
+            <IconPickerModal
+              onSelectIcon={handleIconSelect}
+              onClose={handleModalClose}
+            />
+          )}
+        </BaseLayout>
+      </FolderCreateContainer>
+    </KeyboardAvoidingView>
+  );
+};
+
+const FolderCreateContainer = styled.ScrollView`
+  width: 100%;
+  height: 100%;
+  position: relative;
+`;
+
+const BaseLayout = styled.View`
+  padding: 0 ${scale(22)}px;
+  padding-top: ${Platform.select({ios: scale(25), android: scale(12)})}px;
+`;
+
+const InsertContainer = styled.View`
+  margin: ${scale(20)}px 0;
+`;
+
+const InputWrapper = styled(InputComponent)``;
+
+const FolderCreateText = styled(CustomText)`
+  margin: ${scale(20)}px 0 ${scale(10)}px 0;
+  font-size: ${scale(16)}px;
+`;
+
+export default FolderUpdatePage;


### PR DESCRIPTION
## #️⃣ 연관 이슈
closed #183 
closed #184 

## 📝 작업 내용
### 폴더 수정 페이지 구현

https://github.com/user-attachments/assets/af4d4784-6791-4f7d-96f8-00d047700c1e

폴더 수정 페이지를 구현했습니다. 
구현 과정에서 폴더 정보를 props로 내려줄 수 있도록 일부 페이지, 컴포넌트를 수정했습니다. 


## 💬 리뷰 요구사항(선택)
- 수정 과정에서 발생하는 사이드 이펙트 및 제가 놓친 사항들에 대해 피드백해주시면 좋겠습니다.
- 지금 폴더 컴포넌트에서 글자 수가 길어지면 삐져나오는 문제가 있어서 해결해야겠네요.