### PR TITLE
[FEAT] 타이머 편집 페이지, 폴더 페이지 헤더 고정

### DIFF
--- a/src/pages/FolderPage.jsx
+++ b/src/pages/FolderPage.jsx
@@ -68,16 +68,16 @@ const FolderPage = () => {
 
   return (
     <FolderContainer>
+      <Header
+        type="folder"
+        title={folder?.folderName}
+        icon={folder?.icon}
+        folderId={folder?.id}
+        folder={folder}
+      />
       <ScrollView
         contentContainerStyle={{flexGrow: 1}}
         showsVerticalScrollIndicator={false}>
-        <Header
-          type="folder"
-          title={folder?.folderName}
-          icon={folder?.icon}
-          folderId={folder?.id}
-          folder={folder}
-        />
         <TimersContainer>
           {timers.length > 0 ? (
             timers.map((timer, index) => (

--- a/src/pages/TimerCreatePage.jsx
+++ b/src/pages/TimerCreatePage.jsx
@@ -186,15 +186,17 @@ const TimerCreatePage = () => {
       style={{flex: 1}}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       keyboardVerticalOffset={0}>
+      <HeaderWrapper>
+        <Header
+          type="timerCreate"
+          title="타이머 생성"
+          onPressComplete={saveTimerData}
+        />
+      </HeaderWrapper>
       <TimerCreateContainer
         contentContainerStyle={{flexGrow: 1}}
         showsVerticalScrollIndicator={false}>
         <BaseLayout>
-          <Header
-            type="timerCreate"
-            title="타이머 생성"
-            onPressComplete={saveTimerData}
-          />
           <IconPicker icon={selectedIcon} onSelectIcon={handleIconSelect} />
           <InsertContainer>
             <TimerCreateText weight="semi-bold">타이머 이름</TimerCreateText>
@@ -279,6 +281,11 @@ const PlusButtonWrapper = styled.View`
 
 const TotalTimerContainer = styled.View`
   margin: ${scale(20)}px 0;
+`;
+
+const HeaderWrapper = styled.View`
+  padding: 0 ${scale(21)}px;
+  padding-top: ${Platform.select({ios: scale(25), android: scale(12)})}px;
 `;
 
 export default TimerCreatePage;

--- a/src/pages/TimerUpdatePage.jsx
+++ b/src/pages/TimerUpdatePage.jsx
@@ -182,64 +182,67 @@ const TimerUpdatePage = () => {
       style={{flex: 1}}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       keyboardVerticalOffset={0}>
-      <TimerUpdateContainer
-        contentContainerStyle={{flexGrow: 1}}
-        showsVerticalScrollIndicator={false}>
-        <BaseLayout>
-          <Header
-            type="timerCreate"
-            title="타이머 생성"
-            onPressComplete={saveTimerData}
-          />
-          <IconPicker icon={selectedIcon} onSelectIcon={handleIconSelect} />
-          <InsertContainer>
-            <TimerCreateText weight="semi-bold">타이머 이름</TimerCreateText>
-            <InputWrapper value={timerName} onChangeText={setTimerName} />
-            <TimerCreateText weight="semi-bold">타이머 색상</TimerCreateText>
-            <ColorPicker color={timerColor} onChangeColor={setTimerColor} />
-          </InsertContainer>
-        </BaseLayout>
+      <Wrapper>
+        <Header
+          type="timerCreate"
+          title="타이머 생성"
+          onPressComplete={saveTimerData}
+        />
 
-        <DetailTimerWrapper>
-          {detailTimers.map((time, index) => (
-            <DetailTimer
-              key={time.id}
-              minutes={String(time.minutes).padStart(2, '0')}
-              seconds={String(time.seconds).padStart(2, '0')}
-              fireData={time.fireData}
-              memoData={time.memoData}
-              onDelete={index => {
-                if (detailTimers.length > 1) {
-                  const newDetailTimers = detailTimers.filter(
-                    detailTimer => detailTimer.id !== time.id,
-                  );
-                  setDetailTimers(newDetailTimers);
-                } else {
-                  Alert.alert('최소 1개의 타이머가 설정 되어야합니다.');
+        <TimerUpdateContainer
+          contentContainerStyle={{flexGrow: 1}}
+          showsVerticalScrollIndicator={false}>
+          <BaseLayout>
+            <IconPicker icon={selectedIcon} onSelectIcon={handleIconSelect} />
+            <InsertContainer>
+              <TimerCreateText weight="semi-bold">타이머 이름</TimerCreateText>
+              <InputWrapper value={timerName} onChangeText={setTimerName} />
+              <TimerCreateText weight="semi-bold">타이머 색상</TimerCreateText>
+              <ColorPicker color={timerColor} onChangeColor={setTimerColor} />
+            </InsertContainer>
+          </BaseLayout>
+
+          <DetailTimerWrapper>
+            {detailTimers.map((time, index) => (
+              <DetailTimer
+                key={time.id}
+                minutes={String(time.minutes).padStart(2, '0')}
+                seconds={String(time.seconds).padStart(2, '0')}
+                fireData={time.fireData}
+                memoData={time.memoData}
+                onDelete={() => {
+                  if (detailTimers.length > 1) {
+                    const newDetailTimers = detailTimers.filter(
+                      detailTimer => detailTimer.id !== time.id,
+                    );
+                    setDetailTimers(newDetailTimers);
+                  } else {
+                    Alert.alert('최소 1개의 타이머가 설정 되어야합니다.');
+                  }
+                }}
+                onTimeChange={(minutes, seconds) =>
+                  handleTimeChange(index, minutes, seconds)
                 }
-              }}
-              onTimeChange={(minutes, seconds) =>
-                handleTimeChange(index, minutes, seconds)
-              }
-              onFireChange={newFireData => handleFireChange(index, newFireData)}
-              onMemoChange={newMemoData => handleMemoChange(index, newMemoData)}
-            />
-          ))}
-        </DetailTimerWrapper>
+                onFireChange={newFireData =>
+                  handleFireChange(index, newFireData)
+                }
+                onMemoChange={newMemoData =>
+                  handleMemoChange(index, newMemoData)
+                }
+              />
+            ))}
+          </DetailTimerWrapper>
 
-        <BaseLayout>
-          <PlusButtonWrapper>
-            <PlusButton
-              onPress={() => {
-                addDetailTimer(id);
-              }}
-            />
-          </PlusButtonWrapper>
-          <TotalTimerContainer>
-            <TotalTimer totalTime={[totalMinutes, totalSeconds]} />
-          </TotalTimerContainer>
-        </BaseLayout>
-      </TimerUpdateContainer>
+          <BaseLayout>
+            <PlusButtonWrapper>
+              <PlusButton onPress={() => addDetailTimer(id)} />
+            </PlusButtonWrapper>
+            <TotalTimerContainer>
+              <TotalTimer totalTime={[totalMinutes, totalSeconds]} />
+            </TotalTimerContainer>
+          </BaseLayout>
+        </TimerUpdateContainer>
+      </Wrapper>
     </KeyboardAvoidingView>
   );
 };
@@ -278,6 +281,11 @@ const PlusButtonWrapper = styled.View`
 
 const TotalTimerContainer = styled.View`
   margin: ${scale(20)}px 0;
+`;
+
+const Wrapper = styled.View`
+  flex: 1;
+  background-color: white;
 `;
 
 export default TimerUpdatePage;

--- a/src/pages/TimerUpdatePage.jsx
+++ b/src/pages/TimerUpdatePage.jsx
@@ -182,67 +182,63 @@ const TimerUpdatePage = () => {
       style={{flex: 1}}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       keyboardVerticalOffset={0}>
-      <Wrapper>
+      <HeaderWrapper>
         <Header
           type="timerCreate"
-          title="타이머 생성"
+          title="타이머 편집"
           onPressComplete={saveTimerData}
         />
+      </HeaderWrapper>
 
-        <TimerUpdateContainer
-          contentContainerStyle={{flexGrow: 1}}
-          showsVerticalScrollIndicator={false}>
-          <BaseLayout>
-            <IconPicker icon={selectedIcon} onSelectIcon={handleIconSelect} />
-            <InsertContainer>
-              <TimerCreateText weight="semi-bold">타이머 이름</TimerCreateText>
-              <InputWrapper value={timerName} onChangeText={setTimerName} />
-              <TimerCreateText weight="semi-bold">타이머 색상</TimerCreateText>
-              <ColorPicker color={timerColor} onChangeColor={setTimerColor} />
-            </InsertContainer>
-          </BaseLayout>
+      <TimerUpdateContainer
+        contentContainerStyle={{flexGrow: 1}}
+        showsVerticalScrollIndicator={false}>
+        <BaseLayout>
+          <IconPicker icon={selectedIcon} onSelectIcon={handleIconSelect} />
+          <InsertContainer>
+            <TimerCreateText weight="semi-bold">타이머 이름</TimerCreateText>
+            <InputWrapper value={timerName} onChangeText={setTimerName} />
+            <TimerCreateText weight="semi-bold">타이머 색상</TimerCreateText>
+            <ColorPicker color={timerColor} onChangeColor={setTimerColor} />
+          </InsertContainer>
+        </BaseLayout>
 
-          <DetailTimerWrapper>
-            {detailTimers.map((time, index) => (
-              <DetailTimer
-                key={time.id}
-                minutes={String(time.minutes).padStart(2, '0')}
-                seconds={String(time.seconds).padStart(2, '0')}
-                fireData={time.fireData}
-                memoData={time.memoData}
-                onDelete={() => {
-                  if (detailTimers.length > 1) {
-                    const newDetailTimers = detailTimers.filter(
-                      detailTimer => detailTimer.id !== time.id,
-                    );
-                    setDetailTimers(newDetailTimers);
-                  } else {
-                    Alert.alert('최소 1개의 타이머가 설정 되어야합니다.');
-                  }
-                }}
-                onTimeChange={(minutes, seconds) =>
-                  handleTimeChange(index, minutes, seconds)
+        <DetailTimerWrapper>
+          {detailTimers.map((time, index) => (
+            <DetailTimer
+              key={time.id}
+              minutes={String(time.minutes).padStart(2, '0')}
+              seconds={String(time.seconds).padStart(2, '0')}
+              fireData={time.fireData}
+              memoData={time.memoData}
+              onDelete={() => {
+                if (detailTimers.length > 1) {
+                  const newDetailTimers = detailTimers.filter(
+                    detailTimer => detailTimer.id !== time.id,
+                  );
+                  setDetailTimers(newDetailTimers);
+                } else {
+                  Alert.alert('최소 1개의 타이머가 설정 되어야합니다.');
                 }
-                onFireChange={newFireData =>
-                  handleFireChange(index, newFireData)
-                }
-                onMemoChange={newMemoData =>
-                  handleMemoChange(index, newMemoData)
-                }
-              />
-            ))}
-          </DetailTimerWrapper>
+              }}
+              onTimeChange={(minutes, seconds) =>
+                handleTimeChange(index, minutes, seconds)
+              }
+              onFireChange={newFireData => handleFireChange(index, newFireData)}
+              onMemoChange={newMemoData => handleMemoChange(index, newMemoData)}
+            />
+          ))}
+        </DetailTimerWrapper>
 
-          <BaseLayout>
-            <PlusButtonWrapper>
-              <PlusButton onPress={() => addDetailTimer(id)} />
-            </PlusButtonWrapper>
-            <TotalTimerContainer>
-              <TotalTimer totalTime={[totalMinutes, totalSeconds]} />
-            </TotalTimerContainer>
-          </BaseLayout>
-        </TimerUpdateContainer>
-      </Wrapper>
+        <BaseLayout>
+          <PlusButtonWrapper>
+            <PlusButton onPress={() => addDetailTimer(id)} />
+          </PlusButtonWrapper>
+          <TotalTimerContainer>
+            <TotalTimer totalTime={[totalMinutes, totalSeconds]} />
+          </TotalTimerContainer>
+        </BaseLayout>
+      </TimerUpdateContainer>
     </KeyboardAvoidingView>
   );
 };
@@ -283,9 +279,9 @@ const TotalTimerContainer = styled.View`
   margin: ${scale(20)}px 0;
 `;
 
-const Wrapper = styled.View`
-  flex: 1;
-  background-color: white;
+const HeaderWrapper = styled.View`
+  padding: 0 ${scale(21)}px;
+  padding-top: ${Platform.select({ios: scale(25), android: scale(12)})}px;
 `;
 
 export default TimerUpdatePage;


### PR DESCRIPTION

## #️⃣ 연관 이슈

close #62 

## 📝 작업 내용

<img width="294" alt="image" src="https://github.com/user-attachments/assets/194f0d79-bd32-487e-8d82-cc947b817407" />
<img width="291" alt="image" src="https://github.com/user-attachments/assets/0f33f8ba-bf38-4076-b1f3-98c8a2434fd0" />

타이머 편집 페이지와, 폴더 내부에서 헤더를 고정하였습니다.

## 💬 리뷰 요구사항(선택)