### PR TITLE
[STYLE] safe area view 적용

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -6,6 +6,7 @@ import {useNavigation} from '@react-navigation/native';
 import CustomText from '../CustomText';
 import {useRoute} from '@react-navigation/native';
 import CreateModal from '../modal/createModal/CreateModal';
+import {SafeAreaView} from 'react-native';
 
 const Header = ({type, title, onPressComplete, timer, folder}) => {
   const navigation = useNavigation();
@@ -19,8 +20,55 @@ const Header = ({type, title, onPressComplete, timer, folder}) => {
   if (type === 'main') {
     return (
       <>
+        <SafeAreaView>
+          <HeaderContainer>
+            <Logo source={require('../../assets/images/header/logo.png')} />
+            <IconContainer>
+              <RightTextButton
+                onPress={() => bottomSheetRef.current?.present()}>
+                <IconButton>
+                  <StyledIcon
+                    source={require('../../assets/images/header/plus.png')}
+                  />
+                </IconButton>
+              </RightTextButton>
+            </IconContainer>
+          </HeaderContainer>
+          <CreateModal bottomSheetRef={bottomSheetRef} folder={folder} />
+        </SafeAreaView>
+      </>
+    );
+  } else if (type === 'detail') {
+    return (
+      <SafeAreaView>
         <HeaderContainer>
-          <Logo source={require('../../assets/images/header/logo.png')} />
+          <TouchableWithoutFeedback onPress={() => navigation.goBack()}>
+            <IconButton>
+              <BackButtonIcon
+                source={require('../../assets/images/header/back-icon.png')}
+              />
+            </IconButton>
+          </TouchableWithoutFeedback>
+          <TitleText weight={titleWeight}>{title}</TitleText>
+          <RightTextButton
+            onPress={() => navigation.navigate('Timer Update', {timer})}>
+            <RightText>편집</RightText>
+          </RightTextButton>
+        </HeaderContainer>
+      </SafeAreaView>
+    );
+  } else if (type === 'folder') {
+    return (
+      <SafeAreaView>
+        <HeaderContainer>
+          <TouchableWithoutFeedback onPress={() => navigation.goBack()}>
+            <IconButton>
+              <BackButtonIcon
+                source={require('../../assets/images/header/back-icon.png')}
+              />
+            </IconButton>
+          </TouchableWithoutFeedback>
+          <TitleText weight={titleWeight}>{title}</TitleText>
           <IconContainer>
             <RightTextButton onPress={() => bottomSheetRef.current?.present()}>
               <IconButton>
@@ -30,65 +78,27 @@ const Header = ({type, title, onPressComplete, timer, folder}) => {
               </IconButton>
             </RightTextButton>
           </IconContainer>
+          <CreateModal bottomSheetRef={bottomSheetRef} folder={folder} />
         </HeaderContainer>
-        <CreateModal bottomSheetRef={bottomSheetRef} folder={folder} />
-      </>
-    );
-  } else if (type === 'detail') {
-    return (
-      <HeaderContainer>
-        <TouchableWithoutFeedback onPress={() => navigation.goBack()}>
-          <IconButton>
-            <BackButtonIcon
-              source={require('../../assets/images/header/back-icon.png')}
-            />
-          </IconButton>
-        </TouchableWithoutFeedback>
-        <TitleText weight={titleWeight}>{title}</TitleText>
-        <RightTextButton
-          onPress={() => navigation.navigate('Timer Update', {timer})}>
-          <RightText>편집</RightText>
-        </RightTextButton>
-      </HeaderContainer>
-    );
-  } else if (type === 'folder') {
-    return (
-      <HeaderContainer>
-        <TouchableWithoutFeedback onPress={() => navigation.goBack()}>
-          <IconButton>
-            <BackButtonIcon
-              source={require('../../assets/images/header/back-icon.png')}
-            />
-          </IconButton>
-        </TouchableWithoutFeedback>
-        <TitleText weight={titleWeight}>{title}</TitleText>
-        <IconContainer>
-          <RightTextButton onPress={() => bottomSheetRef.current?.present()}>
-            <IconButton>
-              <StyledIcon
-                source={require('../../assets/images/header/plus.png')}
-              />
-            </IconButton>
-          </RightTextButton>
-        </IconContainer>
-        <CreateModal bottomSheetRef={bottomSheetRef} folder={folder} />
-      </HeaderContainer>
+      </SafeAreaView>
     );
   } else if (['timerCreate', 'folderCreate'].includes(type)) {
     return (
-      <HeaderContainer>
-        <TouchableWithoutFeedback onPress={() => navigation.goBack()}>
-          <IconButton>
-            <BackButtonIcon
-              source={require('../../assets/images/header/back-icon.png')}
-            />
-          </IconButton>
-        </TouchableWithoutFeedback>
-        <TitleText weight={titleWeight}>{title}</TitleText>
-        <RightTextButton onPress={onPressComplete}>
-          <RightText>완료</RightText>
-        </RightTextButton>
-      </HeaderContainer>
+      <SafeAreaView>
+        <HeaderContainer>
+          <TouchableWithoutFeedback onPress={() => navigation.goBack()}>
+            <IconButton>
+              <BackButtonIcon
+                source={require('../../assets/images/header/back-icon.png')}
+              />
+            </IconButton>
+          </TouchableWithoutFeedback>
+          <TitleText weight={titleWeight}>{title}</TitleText>
+          <RightTextButton onPress={onPressComplete}>
+            <RightText>완료</RightText>
+          </RightTextButton>
+        </HeaderContainer>
+      </SafeAreaView>
     );
   }
 };
@@ -99,8 +109,6 @@ const HeaderContainer = styled.View`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  padding: ${scale(10)}px -${scale(10)}px 0 -${scale(10)}px;
-  margin-top: ${scale(25)}px;
   margin-bottom: ${scale(10)}px;
 `;
 

--- a/src/pages/FolderPage.jsx
+++ b/src/pages/FolderPage.jsx
@@ -109,6 +109,7 @@ const TimersContainer = styled.View`
   flex-wrap: wrap;
   justify-content: flex-start;
   padding-top: ${scale(20)}px;
+  padding-bottom: ${scale(30)}px;
 `;
 
 const TimerWrapper = styled.View``;

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -234,6 +234,7 @@ const TimersAndFoldersContainer = styled.View`
   flex-wrap: wrap;
   justify-content: flex-start;
   padding-top: ${scale(20)}px;
+  padding-bottom: ${scale(30)}px;
 `;
 
 const HeaderWrapper = styled.View`


### PR DESCRIPTION

## #️⃣ 연관 이슈
closes #199
 closes #202


## 📝 작업 내용

메인페이지 및 폴더 페이지의 최하단 마진을 설정하여 타이머 하단이 잘리는 문제를 해결하였습니다.
<img width="407" alt="image" src="https://github.com/user-attachments/assets/2d522d10-b698-4eec-9e4d-78bde11e6f91" />
<br>
모든 기기에서 동일한 UI를 가지고자 safearea-view를 적용했습니다.

<img width="859" alt="image" src="https://github.com/user-attachments/assets/98a3cdd1-4106-47d3-86cf-9155de92b5f8" />


## 💬 리뷰 요구사항(선택)