### PR TITLE
[FEAT] 타이머 실행 시 편집 버튼 비활성화

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -116,6 +116,13 @@ const Header = ({
 
 export default Header;
 
+const DisabledRightText = styled(Text)`
+  font-size: ${scale(15)}px;
+  padding: ${scale(10)}px;
+  color: #777777;
+  opacity: 0.5;
+`;
+
 const HeaderContainer = styled.View`
   flex-direction: row;
   justify-content: space-between;

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -8,7 +8,14 @@ import {useRoute} from '@react-navigation/native';
 import CreateModal from '../modal/createModal/CreateModal';
 import {SafeAreaView} from 'react-native';
 
-const Header = ({type, title, onPressComplete, timer, folder}) => {
+const Header = ({
+  type,
+  title,
+  onPressComplete,
+  timer,
+  folder,
+  isTimerRunning,
+}) => {
   const navigation = useNavigation();
   const route = useRoute();
   const titleWeight = Platform.select({
@@ -50,10 +57,14 @@ const Header = ({type, title, onPressComplete, timer, folder}) => {
             </IconButton>
           </TouchableWithoutFeedback>
           <TitleText weight={titleWeight}>{title}</TitleText>
-          <RightTextButton
-            onPress={() => navigation.navigate('Timer Update', {timer})}>
-            <RightText>편집</RightText>
-          </RightTextButton>
+          {isTimerRunning ? (
+            <DisabledRightText>편집</DisabledRightText>
+          ) : (
+            <RightTextButton
+              onPress={() => navigation.navigate('Timer Update', {timer})}>
+              <RightText>편집</RightText>
+            </RightTextButton>
+          )}
         </HeaderContainer>
       </SafeAreaView>
     );

--- a/src/pages/DetailPage.jsx
+++ b/src/pages/DetailPage.jsx
@@ -135,7 +135,14 @@ const DetailPage = () => {
         <Animated.View style={animatedStyle}>
           <DetailTimerContainer>
             <HeaderWrapper>
-              <Header type="detail" title={timer.timerName} timer={timer} />
+              <HeaderWrapper>
+                <Header
+                  type="detail"
+                  title={timer.timerName}
+                  timer={timer}
+                  isTimerRunning={currentTimer?.isRunning}
+                />
+              </HeaderWrapper>
             </HeaderWrapper>
             <ContentContainer>
               <CircularProgress


### PR DESCRIPTION
## #️⃣ 연관 이슈

close #201 

## 📝 작업 내용

<img width="292" alt="image" src="https://github.com/user-attachments/assets/558ff201-6f3e-4dc8-b4a6-c1031b9ea712" />
<img width="291" alt="image" src="https://github.com/user-attachments/assets/2a588f9a-2635-469b-be10-58ffe87eebe8" />

재생 시 편집 버튼이 비활성화 되도록 수정하였습니다. 경고 문구를 띄우기보다는, 편집 버튼의 색상을 투명하게 함으로써 재생 중에는 편집 버튼이 비활성화 된다는 것을 표현하였습니다.

## 💬 리뷰 요구사항(선택)