### PR TITLE
[FIX] TestFlight 배포 환경에서 백그라운드 타이머가 멈추는 문제 해결

### DIFF
--- a/ios/cooktime/Info.plist
+++ b/ios/cooktime/Info.plist
@@ -76,10 +76,6 @@
 		<string>Pretendard-SemiBold.otf</string>
 		<string>Pretendard-Thin.otf</string>
 	</array>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>processing</string>
-	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/src/hooks/useAppStateMonitor.jsx
+++ b/src/hooks/useAppStateMonitor.jsx
@@ -5,14 +5,26 @@ import useTimerStore from '../store';
 export const useAppStateMonitor = () => {
   const appStateRef = useRef(AppState.currentState);
   const syncAllTimers = useTimerStore(state => state.syncAllTimers);
+  const restartIntervals = useTimerStore(state => state.restartIntervals);
+  const clearAllIntervals = useTimerStore(state => state.clearAllIntervals);
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', nextAppState => {
+      if (
+        appStateRef.current === 'active' &&
+        nextAppState.match(/inactive|background/)
+      ) {
+        clearAllIntervals();
+      }
+
       if (
         appStateRef.current.match(/inactive|background/) &&
         nextAppState === 'active'
       ) {
         syncAllTimers();
+        setTimeout(() => {
+          restartIntervals();
+        }, 100);
       }
 
       appStateRef.current = nextAppState;
@@ -21,5 +33,5 @@ export const useAppStateMonitor = () => {
     return () => {
       subscription.remove();
     };
-  }, [syncAllTimers]);
+  }, [syncAllTimers, restartIntervals, clearAllIntervals]);
 };

--- a/src/store.js
+++ b/src/store.js
@@ -392,6 +392,120 @@ const useTimerStore = create(set => ({
       return {timers: updatedTimers};
     });
   },
+
+  restartIntervals: () => {
+    set(state => {
+      const updatedTimers = {...state.timers};
+
+      Object.keys(updatedTimers).forEach(timerId => {
+        const timer = updatedTimers[timerId];
+
+        if (timer.isRunning && timer.startTime && !timer.intervalId) {
+          const intervalId = setInterval(() => {
+            set(innerState => {
+              const currentTimer = innerState.timers[timerId];
+              if (!currentTimer || !currentTimer.isRunning) {
+                clearInterval(intervalId);
+                return innerState;
+              }
+
+              const initialTotalSeconds = calculateTotalSeconds(
+                currentTimer.detailTimerData,
+              );
+
+              const elapsed = Math.floor(
+                (Date.now() - currentTimer.startTime) / 1000,
+              );
+              const newRemainingTotalSeconds = Math.max(
+                initialTotalSeconds - elapsed,
+                0,
+              );
+
+              const {currentStepIndex, currentStepRemaining} =
+                calculateCurrentStep(currentTimer.detailTimerData, elapsed);
+
+              if (newRemainingTotalSeconds === 0) {
+                clearInterval(intervalId);
+
+                return {
+                  timers: {
+                    ...innerState.timers,
+                    [timerId]: {
+                      ...currentTimer,
+                      isRunning: false,
+                      intervalId: null,
+                      currentStepIndex: 0,
+                      time: {
+                        minutes: parseInt(
+                          currentTimer.detailTimerData[0].minutes,
+                        ),
+                        seconds: parseInt(
+                          currentTimer.detailTimerData[0].seconds,
+                        ),
+                      },
+                      remainingTotalSeconds: initialTotalSeconds,
+                      totalTime: {
+                        minutes: Math.floor(initialTotalSeconds / 60),
+                        seconds: initialTotalSeconds % 60,
+                      },
+                      startTime: null,
+                      pausedAt: null,
+                      pausedRemaining: null,
+                    },
+                  },
+                };
+              }
+
+              const minutes = Math.floor(currentStepRemaining / 60);
+              const seconds = currentStepRemaining % 60;
+
+              return {
+                timers: {
+                  ...innerState.timers,
+                  [timerId]: {
+                    ...currentTimer,
+                    currentStepIndex,
+                    time: {minutes, seconds},
+                    remainingTotalSeconds: newRemainingTotalSeconds,
+                    totalTime: {
+                      minutes: Math.floor(newRemainingTotalSeconds / 60),
+                      seconds: newRemainingTotalSeconds % 60,
+                    },
+                  },
+                },
+              };
+            });
+          }, 1000);
+
+          updatedTimers[timerId] = {
+            ...timer,
+            intervalId,
+          };
+        }
+      });
+
+      return {timers: updatedTimers};
+    });
+  },
+
+  clearAllIntervals: () => {
+    set(state => {
+      const updatedTimers = {...state.timers};
+
+      Object.keys(updatedTimers).forEach(timerId => {
+        const timer = updatedTimers[timerId];
+        if (timer.intervalId) {
+          clearInterval(timer.intervalId);
+          updatedTimers[timerId] = {
+            ...timer,
+            intervalId: null,
+          };
+        }
+      });
+
+      return {timers: updatedTimers};
+    });
+  },
 }));
 
 export default useTimerStore;

--- a/src/store.js
+++ b/src/store.js
@@ -2,7 +2,11 @@ import {create} from 'zustand';
 import {Platform} from 'react-native';
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import PushNotification from 'react-native-push-notification';
-import {calculateTotalSeconds, calculateCurrentStep} from './utils/timerUtils';
+import {
+  calculateTotalSeconds,
+  calculateCurrentStep,
+  createTimerIntervalCallback,
+} from './utils/timerUtils';
 
 const useTimerStore = create(set => ({
   timers: {},
@@ -137,84 +141,9 @@ const useTimerStore = create(set => ({
         }
       });
 
-      const intervalId = setInterval(() => {
-        set(state => {
-          const currentTimer = state.timers[timerId];
-          if (!currentTimer || !currentTimer.isRunning) {
-            clearInterval(intervalId);
-            return state;
-          }
-
-          const initialTotalSeconds = calculateTotalSeconds(
-            currentTimer.detailTimerData,
-          );
-
-          const elapsed = Math.floor(
-            (Date.now() - currentTimer.startTime) / 1000,
-          );
-          const newRemainingTotalSeconds = Math.max(
-            initialTotalSeconds - elapsed,
-            0,
-          );
-
-          const {currentStepIndex, currentStepRemaining} = calculateCurrentStep(
-            currentTimer.detailTimerData,
-            elapsed,
-          );
-
-          if (newRemainingTotalSeconds === 0) {
-            clearInterval(intervalId);
-
-            const initialTotalSeconds = calculateTotalSeconds(
-              currentTimer.detailTimerData,
-            );
-
-            return {
-              timers: {
-                ...state.timers,
-                [timerId]: {
-                  ...currentTimer,
-                  isRunning: false,
-                  intervalId: null,
-                  currentStepIndex: 0,
-                  time: {
-                    minutes: parseInt(currentTimer.detailTimerData[0].minutes),
-                    seconds: parseInt(currentTimer.detailTimerData[0].seconds),
-                  },
-                  remainingTotalSeconds: initialTotalSeconds,
-                  totalTime: {
-                    minutes: Math.floor(initialTotalSeconds / 60),
-                    seconds: initialTotalSeconds % 60,
-                  },
-                  startTime: null,
-                  pausedAt: null,
-                  pausedRemaining: null,
-                },
-              },
-            };
-          }
-
-          const minutes = Math.floor(currentStepRemaining / 60);
-          const seconds = currentStepRemaining % 60;
-
-          return {
-            timers: {
-              ...state.timers,
-              [timerId]: {
-                ...currentTimer,
-                currentStepIndex,
-                time: {minutes, seconds},
-                remainingTotalSeconds: newRemainingTotalSeconds,
-                totalTime: {
-                  minutes: Math.floor(newRemainingTotalSeconds / 60),
-                  seconds: newRemainingTotalSeconds % 60,
-                },
-                startTime: currentTimer.startTime,
-              },
-            },
-          };
-        });
-      }, 1000);
+      let intervalId;
+      const intervalCallback = createTimerIntervalCallback(timerId, () => intervalId, set);
+      intervalId = setInterval(intervalCallback, 1000);
 
       return {
         timers: {
@@ -401,81 +330,9 @@ const useTimerStore = create(set => ({
         const timer = updatedTimers[timerId];
 
         if (timer.isRunning && timer.startTime && !timer.intervalId) {
-          const intervalId = setInterval(() => {
-            set(innerState => {
-              const currentTimer = innerState.timers[timerId];
-              if (!currentTimer || !currentTimer.isRunning) {
-                clearInterval(intervalId);
-                return innerState;
-              }
-
-              const initialTotalSeconds = calculateTotalSeconds(
-                currentTimer.detailTimerData,
-              );
-
-              const elapsed = Math.floor(
-                (Date.now() - currentTimer.startTime) / 1000,
-              );
-              const newRemainingTotalSeconds = Math.max(
-                initialTotalSeconds - elapsed,
-                0,
-              );
-
-              const {currentStepIndex, currentStepRemaining} =
-                calculateCurrentStep(currentTimer.detailTimerData, elapsed);
-
-              if (newRemainingTotalSeconds === 0) {
-                clearInterval(intervalId);
-
-                return {
-                  timers: {
-                    ...innerState.timers,
-                    [timerId]: {
-                      ...currentTimer,
-                      isRunning: false,
-                      intervalId: null,
-                      currentStepIndex: 0,
-                      time: {
-                        minutes: parseInt(
-                          currentTimer.detailTimerData[0].minutes,
-                        ),
-                        seconds: parseInt(
-                          currentTimer.detailTimerData[0].seconds,
-                        ),
-                      },
-                      remainingTotalSeconds: initialTotalSeconds,
-                      totalTime: {
-                        minutes: Math.floor(initialTotalSeconds / 60),
-                        seconds: initialTotalSeconds % 60,
-                      },
-                      startTime: null,
-                      pausedAt: null,
-                      pausedRemaining: null,
-                    },
-                  },
-                };
-              }
-
-              const minutes = Math.floor(currentStepRemaining / 60);
-              const seconds = currentStepRemaining % 60;
-
-              return {
-                timers: {
-                  ...innerState.timers,
-                  [timerId]: {
-                    ...currentTimer,
-                    currentStepIndex,
-                    time: {minutes, seconds},
-                    remainingTotalSeconds: newRemainingTotalSeconds,
-                    totalTime: {
-                      minutes: Math.floor(newRemainingTotalSeconds / 60),
-                      seconds: newRemainingTotalSeconds % 60,
-                    },
-                  },
-                },
-              };
-            });
-          }, 1000);
+          let intervalId;
+          const intervalCallback = createTimerIntervalCallback(timerId, () => intervalId, set);
+          intervalId = setInterval(intervalCallback, 1000);
 
           updatedTimers[timerId] = {
             ...timer,

--- a/src/utils/timerUtils.js
+++ b/src/utils/timerUtils.js
@@ -27,3 +27,82 @@ export const calculateCurrentStep = (detailTimerData, elapsed) => {
 
   return {currentStepIndex, currentStepRemaining};
 };
+
+export const createTimerIntervalCallback = (timerId, getIntervalId, set) => {
+  return () => {
+    set(state => {
+      const currentTimer = state.timers[timerId];
+      if (!currentTimer || !currentTimer.isRunning) {
+        const intervalId =
+          typeof getIntervalId === 'function' ? getIntervalId() : getIntervalId;
+        clearInterval(intervalId);
+        return state;
+      }
+
+      const initialTotalSeconds = calculateTotalSeconds(
+        currentTimer.detailTimerData,
+      );
+
+      const elapsed = Math.floor((Date.now() - currentTimer.startTime) / 1000);
+      const newRemainingTotalSeconds = Math.max(
+        initialTotalSeconds - elapsed,
+        0,
+      );
+
+      const {currentStepIndex, currentStepRemaining} = calculateCurrentStep(
+        currentTimer.detailTimerData,
+        elapsed,
+      );
+
+      if (newRemainingTotalSeconds === 0) {
+        const intervalId =
+          typeof getIntervalId === 'function' ? getIntervalId() : getIntervalId;
+        clearInterval(intervalId);
+
+        return {
+          timers: {
+            ...state.timers,
+            [timerId]: {
+              ...currentTimer,
+              isRunning: false,
+              intervalId: null,
+              currentStepIndex: 0,
+              time: {
+                minutes: parseInt(currentTimer.detailTimerData[0].minutes),
+                seconds: parseInt(currentTimer.detailTimerData[0].seconds),
+              },
+              remainingTotalSeconds: initialTotalSeconds,
+              totalTime: {
+                minutes: Math.floor(initialTotalSeconds / 60),
+                seconds: initialTotalSeconds % 60,
+              },
+              startTime: null,
+              pausedAt: null,
+              pausedRemaining: null,
+            },
+          },
+        };
+      }
+
+      const minutes = Math.floor(currentStepRemaining / 60);
+      const seconds = currentStepRemaining % 60;
+
+      return {
+        timers: {
+          ...state.timers,
+          [timerId]: {
+            ...currentTimer,
+            currentStepIndex,
+            time: {minutes, seconds},
+            remainingTotalSeconds: newRemainingTotalSeconds,
+            totalTime: {
+              minutes: Math.floor(newRemainingTotalSeconds / 60),
+              seconds: newRemainingTotalSeconds % 60,
+            },
+            startTime: currentTimer.startTime,
+          },
+        },
+      };
+    });
+  };
+};


### PR DESCRIPTION

## #️⃣ 연관 이슈

> closes #235 

## 📝 작업 내용

TestFlight 배포 환경에서 백그라운드 타이머가 멈추는 문제를 해결했습니다.

**문제 상황**
- 로컬 개발 환경과 Xcode 디바이스 테스트에서는 백그라운드에서 타이머가 정상 작동
- TestFlight 배포 버전에서는 백그라운드로 전환 시 타이머가 멈추거나 시간이 부정확하게 표시되는
현상 발생
- iOS는 앱이 백그라운드로 전환되면 JavaScript 실행을 일시 중단하며, 배포 환경에서는 이 제약이
더 엄격하게 적용됨


**1. `src/store.js`**
  - `restartIntervals()`: 포그라운드 복귀 시 실행 중인 타이머의 interval을 재시작하여 UI 업데이트
  - `clearAllIntervals()`: 백그라운드 전환 시 모든 interval을 정리하여 배터리 절약 및 백그라운드
  제약 대응

**2. `src/hooks/useAppStateMonitor.jsx`**
  - **백그라운드로 전환 시**: `clearAllIntervals()`를 호출하여 모든 setInterval 정리
  - **포그라운드로 복귀 시**:
    - `syncAllTimers()`로 타임스탬프 기반 타이머 상태 동기화
    - `restartIntervals()`로 실행 중인 타이머의 interval 재시작

**3. `ios/cooktime/Info.plist`**
  - `UIBackgroundModes`에서 불필요한 `processing` 모드 제거
  - 로컬 알림은 백그라운드 모드가 필요 없으며, processing 모드는 불필요한 백그라운드 실행을
  야기할 수 있음

