### PR TITLE
[STYLE] 타이머/폴더 롱프레스 시 프리뷰 그림자 잘림 수정

### DIFF
--- a/src/components/timer/CountdownTimer.jsx
+++ b/src/components/timer/CountdownTimer.jsx
@@ -5,18 +5,8 @@ import {Platform, Pressable, Alert} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 import useTimerStore from '../../store';
 import {useEffect} from 'react';
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-  Easing,
-  withRepeat,
-  withSequence,
-  cancelAnimation,
-} from 'react-native-reanimated';
-import DeleteButton from '../common/DeleteButton';
+
 import useUiStore from '../../store/uiStore';
-import ContextMenu from 'react-native-context-menu-view';
 import useDeleteData from '../../hooks/useDeleteData';
 const DetailColor = color => {
   if (color === '#FBDF60') return '#FFC15B';
@@ -77,8 +67,6 @@ const CountdownTimer = ({timer, onTimerClick}) => {
           right: 0,
           width: `${progress * 100}%`,
           height: '100%',
-          borderTopRightRadius: scale(13),
-          borderBottomRightRadius: scale(13),
         }}
       />
       <ContentWrapper>

--- a/src/components/timer/DeleteModeAnimateView.jsx
+++ b/src/components/timer/DeleteModeAnimateView.jsx
@@ -45,11 +45,12 @@ const DeleteModeAnimateView = ({children}) => {
   const animatedStyle = useAnimatedStyle(() => {
     return {
       transform: [{rotate: `${rotation.value}deg`}],
+      overflow: 'visible',
     };
   });
 
   return (
-    <Animated.View style={[{zIndex: 1}, animatedStyle]}>
+    <Animated.View style={[{zIndex: 999, overflow: 'visible'}, animatedStyle]}>
       {children}
     </Animated.View>
   );

--- a/src/components/timer/TimerView.jsx
+++ b/src/components/timer/TimerView.jsx
@@ -57,7 +57,7 @@ const TimerView = ({item, isFolder, onTimerClick, onFolderClick}) => {
         ) : (
           <TimerContextMenu timer={item}>
             <DeleteModeAnimateView>
-              <CountdownTimer timer={item} onTimerClick={onTimerClick} />
+              <CountdownTimer timer={item} />
             </DeleteModeAnimateView>
           </TimerContextMenu>
         )}

--- a/src/components/timer/TimerView.jsx
+++ b/src/components/timer/TimerView.jsx
@@ -46,16 +46,17 @@ const TimerView = ({item, isFolder, onTimerClick, onFolderClick}) => {
       <Pressable
         onPress={handlePress}
         onLongPress={() => {}}
-        delayLongPress={200}>
+        delayLongPress={200}
+        style={{overflow: 'visible', zIndex: 999}}>
         {isFolder ? (
           <FolderContextMenu folder={item}>
-            <DeleteModeAnimateView style={{zIndex: 1, backgroundColor: 'red'}}>
+            <DeleteModeAnimateView>
               <CountdownFolder folder={item} onFolderClick={onFolderClick} />
             </DeleteModeAnimateView>
           </FolderContextMenu>
         ) : (
           <TimerContextMenu timer={item}>
-            <DeleteModeAnimateView style={{zIndex: 1, backgroundColor: 'red'}}>
+            <DeleteModeAnimateView>
               <CountdownTimer timer={item} onTimerClick={onTimerClick} />
             </DeleteModeAnimateView>
           </TimerContextMenu>
@@ -68,10 +69,12 @@ const TimerView = ({item, isFolder, onTimerClick, onFolderClick}) => {
 export default TimerView;
 
 const TimerViewContainer = styled.View`
-  z-index: 1;
+  z-index: 999;
   position: relative;
+  overflow: visible;
 `;
 
 const DeleteButtonWrapper = styled.View`
   ${props => props.isFolder && `top: ${scale(15)}px;`}
+  z-index: 1000;
 `;

--- a/src/pages/FolderPage.jsx
+++ b/src/pages/FolderPage.jsx
@@ -86,8 +86,9 @@ const FolderPage = () => {
         folder={folder}
       />
       <ScrollView
-        contentContainerStyle={{flexGrow: 1}}
-        showsVerticalScrollIndicator={false}>
+        contentContainerStyle={{flexGrow: 1, overflow: 'visible'}}
+        showsVerticalScrollIndicator={false}
+        style={{overflow: 'visible'}}>
         <TimersContainer
           onPress={() => {
             isDeleteMode && setDeleteMode(false);
@@ -128,9 +129,14 @@ const TimersContainer = styled.Pressable`
   justify-content: flex-start;
   padding-top: ${scale(20)}px;
   padding-bottom: ${scale(30)}px;
+  overflow: visible;
 `;
 
-const TimerWrapper = styled.View``;
+const TimerWrapper = styled.View`
+  z-index: 999;
+  elevation: 999;
+  overflow: visible;
+`;
 
 const EmptyView = styled.View`
   flex: 1;

--- a/src/pages/mainView/MainPage.jsx
+++ b/src/pages/mainView/MainPage.jsx
@@ -178,8 +178,9 @@ const MainPage = ({width}) => {
   return (
     <MainContainer width={width}>
       <ScrollView
-        contentContainerStyle={{flexGrow: 1}}
-        showsVerticalScrollIndicator={false}>
+        contentContainerStyle={{flexGrow: 1, overflow: 'visible'}}
+        showsVerticalScrollIndicator={false}
+        style={{overflow: 'visible'}}>
         <HeaderWrapper>
           <Header type="main" />
         </HeaderWrapper>
@@ -225,6 +226,7 @@ const CountdownTimerWrapper = styled.Pressable`
   margin: 0 ${scale(21)}px;
   height: 100%;
   width: 100%;
+  overflow: visible;
 `;
 
 const TimersAndFoldersContainer = styled.View`
@@ -234,6 +236,7 @@ const TimersAndFoldersContainer = styled.View`
   justify-content: flex-start;
   padding-top: ${scale(20)}px;
   padding-bottom: ${scale(30)}px;
+  overflow: visible;
 `;
 
 const HeaderWrapper = styled.View`


### PR DESCRIPTION

## #️⃣ 연관 이슈

> closes #236 

## 📝 작업 내용

iOS에서 타이머/폴더를 롱프레스 할 때 ContextMenuView의 프리뷰 그림자가 잘리는 현상을
수정했습니다.

- ScrollView, TimersContainer 등 여러 부모 컨테이너에서 기본 `overflow` 설정으로 인해 그림자 잘림
- `TimerContainer`에 `overflow: hidden`이 설정되어 있어 ContextMenuView의 그림자가 컨테이너 밖으로 나가지 못함
- z-index 값이 낮아 형제 요소들과 레이어 충돌 발생

**수정 전**
<img width="1170" height="867" alt="image" src="https://github.com/user-attachments/assets/efafeafb-b68a-42ed-97a8-0112e4cf3d0c" />

**수정 후**
<img width="1170" height="921" alt="image" src="https://github.com/user-attachments/assets/69cfc437-1485-4a00-8565-2180b445b06d" />

